### PR TITLE
Add `Backup::handle()` method as a wrapper around `Backup::fire()`

### DIFF
--- a/src/Cmd/Backup.php
+++ b/src/Cmd/Backup.php
@@ -81,6 +81,15 @@ class Backup extends Command
     }
 
     /**
+     * @throws \Exception
+     * @return bool
+     */
+    public function handle()
+    {
+        return $this->fire();
+    }
+
+    /**
      * Creates a phpbu configuration.
      *
      * @return \phpbu\App\Configuration

--- a/tests/phpbu-laravel/Cmd/BackupTest.php
+++ b/tests/phpbu-laravel/Cmd/BackupTest.php
@@ -47,7 +47,7 @@ class BackupTest extends \PHPUnit\Framework\TestCase
                 ->method('option')
                 ->willReturn(false);
 
-        $this->assertTrue($command->fire());
+        $this->assertTrue($command->handle());
     }
 
     /**
@@ -71,7 +71,7 @@ class BackupTest extends \PHPUnit\Framework\TestCase
                         ->setConstructorArgs([$runner, $proxy])
                         ->getMock();
 
-        $command->fire();
+        $command->handle();
     }
 
     /**
@@ -114,6 +114,6 @@ class BackupTest extends \PHPUnit\Framework\TestCase
                 ->method('option')
                 ->willReturn(false);
 
-        $this->assertTrue($command->fire());
+        $this->assertTrue($command->handle());
     }
 }


### PR DESCRIPTION
This is required because the Laravel command class overrides the basic
`Command::execute()` method of the Symfony Console class and calls
the `handle()` method of the respective concrete command.

Fixes https://github.com/sebastianfeldmann/phpbu-laravel/issues/4